### PR TITLE
add widthOffset to rect

### DIFF
--- a/src/scripts/chartist-plugin-zoom.js
+++ b/src/scripts/chartist-plugin-zoom.js
@@ -52,15 +52,16 @@
         var defs = data.svg.querySelector('defs') || data.svg.elem('defs');
         var width = chartRect.width();
         var height = chartRect.height();
+        var widthOffset = 5;
 
         defs
           .elem('clipPath', {
             id: 'zoom-mask'
           })
           .elem('rect', {
-            x: chartRect.x1,
+            x: chartRect.x1 - widthOffset,
             y: chartRect.y2,
-            width: width,
+            width: width + (widthOffset * 2),
             height: height,
             fill: 'white'
           });


### PR DESCRIPTION
Prevent stripping the points on the rects on some graphs, as an example, this is my graph before and after this change, the change is noticeable in the first and last points of each line.

_Before_
![screen shot 2016-10-06 at 11 51 12 am](https://cloud.githubusercontent.com/assets/1993929/19161962/89fb39b2-8bbb-11e6-9301-2e27f31ce1e4.png)

_After_
![screen shot 2016-10-06 at 11 51 24 am](https://cloud.githubusercontent.com/assets/1993929/19161978/9bffb05c-8bbb-11e6-951e-217b5191496e.png)
