### PR TITLE
Don't clip every single point

### DIFF
--- a/src/scripts/chartist-plugin-zoom.js
+++ b/src/scripts/chartist-plugin-zoom.js
@@ -29,9 +29,8 @@
 
       chart.on('draw', function (data) {
         var type = data.type;
-        var mask = type === 'point' ? 'point-mask' : 'line-mask';
-        if (type === 'line' || type === 'bar' || type === 'area' || type === 'point') {
-          data.element.attr({ 'clip-path': 'url(#' + mask + ')' });
+        if (type === 'line' || type === 'bar' || type === 'area') {
+          data.element.attr({ 'clip-path': 'url(#line-mask)' });
         }
       });
 
@@ -67,7 +66,11 @@
         }
         addMask('line-mask', 0);
         addMask('point-mask', options.pointClipOffset);
-
+        var series = chart.svg.querySelectorAll("." + data.options.classNames.series).svgElements;
+        for(var i=0; i < series.length; ++i){
+          series[i].attr({'clip-path': 'url(#point-mask)'});
+        }
+        
         function on(event, handler) {
           svg.addEventListener(event, handler);
         }


### PR DESCRIPTION
This PR changes the clipping behavior to only require one 'clip-path' attribute per series plus one for each line, bar and area.
Previously a 'clip-path' attribute was set for each point, which for graphs with many points can lead to performance problems (Although not *really* dramatic ones TBH).
Anyhow this shouldn't harm and increase the performance a bit.